### PR TITLE
タグ機能実装

### DIFF
--- a/src/app/Article.php
+++ b/src/app/Article.php
@@ -35,4 +35,9 @@ class Article extends Model
     {
         return $this->likes->count();
     }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Tag')->withTimestamps();
+    }
 }

--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -40,12 +40,25 @@ class ArticleController extends Controller
 
     public function edit(Article $article)
     {
-        return view('articles.edit', ['article' => $article]);
+        $tagNames = $article->tags->map(function($tag) {
+            return ['text' => $tag->name];
+        });
+
+        return view('articles.edit', [
+            'article' => $article,
+            'tagNames' => $tagNames,
+        ]);
     }
 
     public function update(ArticleRequest $request, Article $article)
     {
         $article->fill($request->all())->save();
+
+        $article->tags()->detach();
+        $request->tags->each(function($tagName) use ($article) {
+            $tag = Tag::firstOrCreate(['name' => $tagName]);
+            $article->tags()->attach($tag);
+        });
         return redirect()->route('articles.index');
     }
 

--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Article;
+use App\Tag;
 use App\Http\Requests\ArticleRequest;
 use Illuminate\Http\Request;
 
@@ -30,6 +31,10 @@ class ArticleController extends Controller
         $article->fill($request->all());
         $article->user_id = $request->user()->id;
         $article->save();
+        $request->tags->each(function($tagName) use ($article) {
+            $tag = Tag::firstOrCreate(['name' => $tagName]);
+            $article->tags()->attach($tag);
+        });
         return redirect()->route('articles.index');
     }
 

--- a/src/app/Http/Requests/ArticleRequest.php
+++ b/src/app/Http/Requests/ArticleRequest.php
@@ -26,6 +26,7 @@ class ArticleRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'body' => 'required|max:500',
+            'tags' => 'json|regex:/^(?!.*\s).+$/u|regex:/^(?!.*\/).*$/u',
         ];
     }
 
@@ -34,6 +35,16 @@ class ArticleRequest extends FormRequest
         return [
             'title' => 'タイトル',
             'body' => '本文',
+            'tags' => 'タグ',
         ]; 
+    }
+
+    public function passedValidation()
+    {
+        $this->tags = collect(json_decode($this->tags))
+          ->slice(0, 5)
+          ->map(function($requestTag) {
+            return $requestTag->text;
+          }); 
     }
 }

--- a/src/app/Tag.php
+++ b/src/app/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/src/database/migrations/2023_06_11_071201_create_tags_table.php
+++ b/src/database/migrations/2023_06_11_071201_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/src/database/migrations/2023_06_11_071444_create_article_tag_table.php
+++ b/src/database/migrations/2023_06_11_071444_create_article_tag_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticleTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('article_id');
+            $table->foreign('article_id')
+                  ->references('id')
+                  ->on('articles')
+                  ->onDelete('cascade');
+            $table->unsignedBigInteger('tag_id')
+                  ->references('id')
+                  ->on('tags')
+                  ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,6 +10,7 @@
                 "popper.js": "^1.16.1"
             },
             "devDependencies": {
+                "@johmun/vue-tags-input": "^2.1.0",
                 "axios": "^0.19",
                 "cross-env": "^5.1",
                 "laravel-mix": "^4.0.7",
@@ -1614,6 +1615,18 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@johmun/vue-tags-input": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+            "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+            "dev": true,
+            "dependencies": {
+                "vue": "^2.6.10"
+            },
+            "peerDependencies": {
+                "vue": "2.x"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -14192,6 +14205,13 @@
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "to-fast-properties": "^2.0.0"
             }
+        },
+        "@johmun/vue-tags-input": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+            "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+            "dev": true,
+            "requires": {}
         },
         "@jridgewell/gen-mapping": {
             "version": "0.3.3",

--- a/src/package.json
+++ b/src/package.json
@@ -10,6 +10,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
+        "@johmun/vue-tags-input": "^2.1.0",
         "axios": "^0.19",
         "cross-env": "^5.1",
         "laravel-mix": "^4.0.7",

--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -1,10 +1,12 @@
 import './bootstrap'
 import Vue from 'vue'
 import ArticleLike from './components/ArticleLike'
+import ArticleTagsInput from './components/ArticleTagsInput'
 
 const app = new Vue({
   el: '#app',
   components: {
     ArticleLike,
+    ArticleTagsInput,
   }
 })

--- a/src/resources/js/components/ArticleTagsInput.vue
+++ b/src/resources/js/components/ArticleTagsInput.vue
@@ -22,10 +22,16 @@ export default {
   components: {
     VueTagsInput,
   },
+  props: {
+    initialTags: {
+      type: Array,
+      default: [],
+    }
+  },
   data() {
     return {
       tag: '',
-      tags: [],
+      tags: this.initialTags,
       autocompleteItems: [{
         text: 'Spain',
       }, {

--- a/src/resources/js/components/ArticleTagsInput.vue
+++ b/src/resources/js/components/ArticleTagsInput.vue
@@ -1,0 +1,68 @@
+<template>
+  <div>
+    <input
+      type='hidden'
+      name='tags'
+      :value="tagsJson"
+    >
+    <vue-tags-input 
+      v-model="tag"
+      :tags = "tags"
+      placeholder='タグは５個まで入力できます'
+      :autocomplete-items="filteredItems"
+      @tags-changed="newTags => tags = newTags"
+    />
+  </div>
+</template>
+
+<script>
+import VueTagsInput from '@johmun/vue-tags-input';
+
+export default {
+  components: {
+    VueTagsInput,
+  },
+  data() {
+    return {
+      tag: '',
+      tags: [],
+      autocompleteItems: [{
+        text: 'Spain',
+      }, {
+        text: 'France',
+      }, {
+        text: 'USA',
+      }, {
+        text: 'Germany',
+      }, {
+        text: 'Chine',
+      }],
+    };
+  },
+  computed: {
+    filteredItems() {
+      return this.autocompleteItems.filter(i => {
+        return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
+      });
+    },
+    tagsJson() {
+      return JSON.stringify(this.tags)
+    },
+  },
+};
+</script>
+<style lang="css" scoped>
+  .vue-tags-input {
+    max-width: inherit;
+  }
+</style>
+<style lang="css">
+  .vue-tags-input .ti-tag {
+    background: transparent;
+    border: 1px solid #747373;
+    color: #747373;
+    margin-right: 4px;
+    border-radius: 0px;
+    font-size: 13px;
+  }
+</style>

--- a/src/resources/views/articles/card.blade.php
+++ b/src/resources/views/articles/card.blade.php
@@ -74,5 +74,17 @@
       </article-like>
     </div>
   </div>
+  @foreach($article->tags as $tag)
+    @if($loop->first)
+    <div class='card-body pt-0 pb-4 pl-3'>
+      <div class='cardtext line-height'>
+    @endif
+      <a href="" class='border p-1 mr-1 text-muted'>
+        {{ $tag->name }}
+      </a>
+    @if($loop->last)
+      </div>
+    </div>
+    @endif
+  @endforeach
 </div>
-

--- a/src/resources/views/articles/form.blade.php
+++ b/src/resources/views/articles/form.blade.php
@@ -3,6 +3,11 @@
   <label>タイトル</label>
   <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
+<div class='form-group'>
+  <article-tags-input
+  >
+  </article-tags-input>
+</div>
 <div class="form-group">
   <label></label>
   <textarea name="body" required class="form-control" rows="16" placeholder="本文">{{ $article->body ?? old('body') }}</textarea>

--- a/src/resources/views/articles/form.blade.php
+++ b/src/resources/views/articles/form.blade.php
@@ -5,6 +5,7 @@
 </div>
 <div class='form-group'>
   <article-tags-input
+    :initial-tags = '@json($tagNames ?? [])'
   >
   </article-tags-input>
 </div>


### PR DESCRIPTION
### 概要
Tag機能をVueを使用して実装した。

### 実装内容
ArticleとTagが多対多の関係で実装、中間テーブルを用意している。
TagはJson形式で受け取ってコントローラで配列にするよう処理している。
ビューではタグ入力用にVue関連のパッケージをインストール、POST通信は同期で実装した。
バリデーションも`ArticleRequest.php`に追加実装した。
### 画面
以下、画面です。
#### 一覧画面
[![Image from Gyazo](https://i.gyazo.com/b66c706563e57318ac9dd2bb8641398f.png)](https://gyazo.com/b66c706563e57318ac9dd2bb8641398f)
#### 詳細画面
[![Image from Gyazo](https://i.gyazo.com/9868d686f1fd40ce478b55ddc46e638e.png)](https://gyazo.com/9868d686f1fd40ce478b55ddc46e638e)
#### 編集画面
[![Image from Gyazo](https://i.gyazo.com/e4254d8fd0fbb909b19d893467fa8e27.png)](https://gyazo.com/e4254d8fd0fbb909b19d893467fa8e27)
### 次回実装
次回はタグ機能を向上させる実装をする。